### PR TITLE
feat(linalg): add matmul, transpose, det, inv, lu, cholesky, backend API

### DIFF
--- a/mtl5/__init__.py
+++ b/mtl5/__init__.py
@@ -1,6 +1,9 @@
 """MTL5 Python bindings — NumPy/SciPy/JAX/PyTorch interop with hardware accelerator dispatch."""
 
 from mtl5._core import (
+    # Cholesky factorization objects
+    CholeskyFactor_f32,
+    CholeskyFactor_f64,
     # Native IEEE types (zero-copy views)
     DenseMatrix_f32,
     DenseMatrix_f64,
@@ -15,26 +18,49 @@ from mtl5._core import (
     DenseVector_fp16,
     DenseVector_i32,
     DenseVector_i64,
+    # LU factorization objects
+    LUFactor_f32,
+    LUFactor_f64,
     __version__,
+    # Backend management
+    backends,
+    cholesky,
     # Device management
     devices,
-    # Operations (auto-dispatch on input dtype for native types)
+    # Operations
     dot,
+    get_backend,
+    inv,
+    lu,
+    matmul,
     matrix,
     matrix_copy,
     matrix_fp8,
     matrix_fp16,
+    matvec,
     norm,
+    set_backend,
     solve,
+    transpose,
     vector,
     vector_copy,
     vector_fp8,
     vector_fp16,
 )
+from mtl5._core import det as _det
 
 # Convenience aliases — default to f64
 DenseVector = DenseVector_f64
 DenseMatrix = DenseMatrix_f64
+LUFactor = LUFactor_f64
+CholeskyFactor = CholeskyFactor_f64
+
+
+# Re-export det (avoids shadowing the builtin namespace)
+def det(A):
+    """Compute the determinant of a matrix via LU factorization."""
+    return _det(A)
+
 
 __all__ = [
     "__version__",
@@ -54,16 +80,33 @@ __all__ = [
     "DenseMatrix_fp16",
     "DenseMatrix_i32",
     "DenseMatrix_i64",
-    # Device management
+    # Factorization classes
+    "LUFactor",
+    "LUFactor_f32",
+    "LUFactor_f64",
+    "CholeskyFactor",
+    "CholeskyFactor_f32",
+    "CholeskyFactor_f64",
+    # Device & backend management
+    "backends",
     "devices",
+    "get_backend",
+    "set_backend",
     # Operations
+    "cholesky",
+    "det",
     "dot",
+    "inv",
+    "lu",
+    "matmul",
     "matrix",
     "matrix_copy",
     "matrix_fp8",
     "matrix_fp16",
+    "matvec",
     "norm",
     "solve",
+    "transpose",
     "vector",
     "vector_copy",
     "vector_fp8",

--- a/python/src/mtl5_module.cpp
+++ b/python/src/mtl5_module.cpp
@@ -10,6 +10,9 @@
 #include <mtl/operation/dot.hpp>
 #include <mtl/operation/operators.hpp>
 #include <mtl/operation/lu.hpp>
+#include <mtl/operation/cholesky.hpp>
+#include <mtl/operation/mult.hpp>
+#include <mtl/operation/inv.hpp>
 
 // Universal number types
 #include <universal/number/cfloat/cfloat.hpp>
@@ -104,13 +107,16 @@ void register_native_vector(nb::module_& m) {
         .def_prop_ro("dtype", [](const VV&) { return type_suffix<T>(); })
         .def_prop_ro("device", [](const VV& vv) { return vv.device_name; })
         .def_prop_ro("is_view", [](const VV& vv) { return vv.is_view(); })
-        .def("to_numpy", [](VV& vv) {
-            // Zero-copy: return a NumPy array that shares memory with this vector
+        .def("to_numpy", [](nb::handle self) {
+            // Zero-copy: return a NumPy array that shares memory with this vector.
+            // Use nb::handle to get the actual Python wrapper object as the
+            // keep-alive owner — nb::cast(vv) on a C++ reference creates a
+            // separate copy whose data() differs from the source, causing
+            // use-after-free on chained calls like solve(b).to_numpy().
+            VV& vv = nb::cast<VV&>(self);
             std::size_t shape[1] = { vv.vec.size() };
-            // The capsule prevents this VectorView from being GC'd while
-            // the NumPy array exists, keeping the memory alive
             return nb::ndarray<nb::numpy, T, nb::ndim<1>>(
-                vv.vec.data(), 1, shape, nb::cast(vv));
+                vv.vec.data(), 1, shape, self);
         }, "Return a zero-copy NumPy array view of this vector")
         .def("copy", [](const VV& vv) {
             auto owned = mtl::vec::dense_vector<T>(vv.vec.size());
@@ -171,12 +177,49 @@ void register_native_matrix(nb::module_& m) {
                 throw nb::index_error();
             mv.mat(idx.first, idx.second) = val;
         })
-        .def("to_numpy", [](MV& mv) {
-            // Zero-copy: return a NumPy array that shares memory
+        .def("to_numpy", [](nb::handle self) {
+            // Use nb::handle for keep-alive — see VectorView::to_numpy comment.
+            MV& mv = nb::cast<MV&>(self);
             std::size_t shape[2] = { mv.mat.num_rows(), mv.mat.num_cols() };
             return nb::ndarray<nb::numpy, T, nb::ndim<2>>(
-                mv.mat.data(), 2, shape, nb::cast(mv));
+                mv.mat.data(), 2, shape, self);
         }, "Return a zero-copy NumPy array view of this matrix")
+        .def_prop_ro("T", [](const MV& mv) {
+            std::size_t r = mv.mat.num_rows(), c = mv.mat.num_cols();
+            mtl::mat::dense2D<T> AT(c, r);
+            for (std::size_t i = 0; i < r; ++i)
+                for (std::size_t j = 0; j < c; ++j)
+                    AT(j, i) = mv.mat(i, j);
+            return MV(std::move(AT));
+        })
+        .def("__matmul__", [](const MV& A, const MV& B) {
+            if (A.mat.num_cols() != B.mat.num_rows())
+                throw std::invalid_argument("matmul: A.num_cols != B.num_rows");
+            mtl::mat::dense2D<T> Ac(A.mat.num_rows(), A.mat.num_cols());
+            for (std::size_t i = 0; i < A.mat.num_rows(); ++i)
+                for (std::size_t j = 0; j < A.mat.num_cols(); ++j)
+                    Ac(i, j) = A.mat(i, j);
+            mtl::mat::dense2D<T> Bc(B.mat.num_rows(), B.mat.num_cols());
+            for (std::size_t i = 0; i < B.mat.num_rows(); ++i)
+                for (std::size_t j = 0; j < B.mat.num_cols(); ++j)
+                    Bc(i, j) = B.mat(i, j);
+            mtl::mat::dense2D<T> C(Ac.num_rows(), Bc.num_cols());
+            mtl::mult(Ac, Bc, C);
+            return MV(std::move(C));
+        })
+        .def("__matmul__", [](const MV& A, const VectorView<T>& x) {
+            if (A.mat.num_cols() != x.vec.size())
+                throw std::invalid_argument("matmul: A.num_cols != len(x)");
+            mtl::mat::dense2D<T> Ac(A.mat.num_rows(), A.mat.num_cols());
+            for (std::size_t i = 0; i < A.mat.num_rows(); ++i)
+                for (std::size_t j = 0; j < A.mat.num_cols(); ++j)
+                    Ac(i, j) = A.mat(i, j);
+            mtl::vec::dense_vector<T> xc(x.vec.size());
+            for (std::size_t i = 0; i < x.vec.size(); ++i) xc[i] = x.vec[i];
+            mtl::vec::dense_vector<T> y(A.mat.num_rows());
+            mtl::mult(Ac, xc, y);
+            return VectorView<T>(std::move(y));
+        })
         .def("copy", [](const MV& mv) {
             auto owned = mtl::mat::dense2D<T>(mv.mat.num_rows(), mv.mat.num_cols());
             for (std::size_t r = 0; r < mv.mat.num_rows(); ++r)
@@ -371,6 +414,277 @@ void register_native_solve(nb::module_& m) {
 }
 
 // ===========================================================================
+// LUFactor<T> — wraps an LU factorization (LU matrix + pivot vector)
+// Returned by mtl5.lu(A); supports .solve(b) for repeated solves.
+// ===========================================================================
+template <typename T>
+struct LUFactor {
+    mtl::mat::dense2D<T> LU;
+    std::vector<std::size_t> pivot;
+    std::size_t n;
+
+    LUFactor(const mtl::mat::dense2D<T>& A)
+        : LU(A.num_rows(), A.num_cols()), n(A.num_rows())
+    {
+        // Copy A into LU (lu_factor is in-place)
+        for (std::size_t r = 0; r < n; ++r)
+            for (std::size_t c = 0; c < n; ++c)
+                LU(r, c) = A(r, c);
+        int info = mtl::lu_factor(LU, pivot);
+        if (info != 0)
+            throw std::runtime_error("lu: singular matrix (zero pivot at row " +
+                                     std::to_string(info - 1) + ")");
+    }
+};
+
+// ===========================================================================
+// CholeskyFactor<T> — wraps a Cholesky factorization (lower triangular L)
+// Returned by mtl5.cholesky(A); supports .solve(b) for repeated SPD solves.
+// ===========================================================================
+template <typename T>
+struct CholeskyFactor {
+    mtl::mat::dense2D<T> L;
+    std::size_t n;
+
+    CholeskyFactor(const mtl::mat::dense2D<T>& A)
+        : L(A.num_rows(), A.num_cols()), n(A.num_rows())
+    {
+        for (std::size_t r = 0; r < n; ++r)
+            for (std::size_t c = 0; c < n; ++c)
+                L(r, c) = A(r, c);
+        int info = mtl::cholesky_factor(L);
+        if (info != 0)
+            throw std::runtime_error(
+                "cholesky: matrix is not symmetric positive definite "
+                "(failure at row " + std::to_string(info - 1) + ")");
+    }
+};
+
+// ---------------------------------------------------------------------------
+// Helpers to copy a MatrixView/ndarray into an owning dense2D
+// ---------------------------------------------------------------------------
+template <typename T>
+mtl::mat::dense2D<T> copy_to_dense(const MatrixView<T>& mv) {
+    std::size_t r = mv.mat.num_rows(), c = mv.mat.num_cols();
+    mtl::mat::dense2D<T> out(r, c);
+    for (std::size_t i = 0; i < r; ++i)
+        for (std::size_t j = 0; j < c; ++j)
+            out(i, j) = mv.mat(i, j);
+    return out;
+}
+
+template <typename T>
+mtl::mat::dense2D<T> copy_ndarray_to_dense(
+    nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu> a)
+{
+    std::size_t r = a.shape(0), c = a.shape(1);
+    mtl::mat::dense2D<T> out(r, c);
+    const T* src = a.data();
+    for (std::size_t i = 0; i < r; ++i)
+        for (std::size_t j = 0; j < c; ++j)
+            out(i, j) = src[i * c + j];
+    return out;
+}
+
+// ---------------------------------------------------------------------------
+// register_native_dense_ops<T> — matmul, transpose, det, inv, lu, cholesky
+// ---------------------------------------------------------------------------
+template <typename T>
+    requires std::is_floating_point_v<T>
+void register_native_dense_ops(nb::module_& m) {
+    using Mat = mtl::mat::dense2D<T>;
+    using Vec = mtl::vec::dense_vector<T>;
+    using MV  = MatrixView<T>;
+    using VV  = VectorView<T>;
+
+    // -- matmul (matrix × matrix) -----------------------------------------
+    m.def("matmul", [](const MV& A_mv, const MV& B_mv) {
+        if (A_mv.mat.num_cols() != B_mv.mat.num_rows())
+            throw std::invalid_argument(
+                "matmul: A.num_cols must equal B.num_rows");
+        Mat A = copy_to_dense(A_mv);
+        Mat B = copy_to_dense(B_mv);
+        Mat C(A.num_rows(), B.num_cols());
+        mtl::mult(A, B, C);
+        return MV(std::move(C));
+    }, "A"_a, "B"_a, "Matrix-matrix multiplication: C = A @ B");
+
+    // matmul accepting ndarray inputs
+    m.def("matmul",
+          [](nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu> A_np,
+             nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu> B_np) {
+        if (A_np.shape(1) != B_np.shape(0))
+            throw std::invalid_argument(
+                "matmul: A.num_cols must equal B.num_rows");
+        Mat A = copy_ndarray_to_dense<T>(A_np);
+        Mat B = copy_ndarray_to_dense<T>(B_np);
+        Mat C(A.num_rows(), B.num_cols());
+        mtl::mult(A, B, C);
+        return MV(std::move(C));
+    }, "A"_a, "B"_a);
+
+    // matrix-vector multiplication
+    m.def("matvec", [](const MV& A_mv, const VV& x_vv) {
+        if (A_mv.mat.num_cols() != x_vv.vec.size())
+            throw std::invalid_argument(
+                "matvec: A.num_cols must equal len(x)");
+        Mat A = copy_to_dense(A_mv);
+        Vec x(x_vv.vec.size());
+        for (std::size_t i = 0; i < x_vv.vec.size(); ++i) x[i] = x_vv.vec[i];
+        Vec y(A.num_rows());
+        mtl::mult(A, x, y);
+        return VV(std::move(y));
+    }, "A"_a, "x"_a, "Matrix-vector multiplication: y = A @ x");
+
+    // -- transpose (out-of-place copy for now) ----------------------------
+    m.def("transpose", [](const MV& A_mv) {
+        std::size_t r = A_mv.mat.num_rows(), c = A_mv.mat.num_cols();
+        Mat AT(c, r);
+        for (std::size_t i = 0; i < r; ++i)
+            for (std::size_t j = 0; j < c; ++j)
+                AT(j, i) = A_mv.mat(i, j);
+        return MV(std::move(AT));
+    }, "A"_a, "Return the transpose of A");
+
+    // -- det (via LU factorization) ---------------------------------------
+    auto compute_det = [](Mat&& LU) -> double {
+        std::size_t n = LU.num_rows();
+        std::vector<std::size_t> pivot;
+        int info = mtl::lu_factor(LU, pivot);
+        if (info != 0)
+            return 0.0;
+        double d = 1.0;
+        std::size_t swaps = 0;
+        for (std::size_t i = 0; i < n; ++i) {
+            d *= static_cast<double>(LU(i, i));
+            if (pivot[i] != i) ++swaps;
+        }
+        if (swaps % 2 == 1) d = -d;
+        return d;
+    };
+
+    m.def("det", [compute_det](const MV& A_mv) -> double {
+        if (A_mv.mat.num_cols() != A_mv.mat.num_rows())
+            throw std::invalid_argument("det: A must be square");
+        return compute_det(copy_to_dense(A_mv));
+    }, "A"_a, "Compute determinant via LU factorization");
+
+    m.def("det",
+          [compute_det](nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu> A_np)
+          -> double {
+        if (A_np.shape(0) != A_np.shape(1))
+            throw std::invalid_argument("det: A must be square");
+        return compute_det(copy_ndarray_to_dense<T>(A_np));
+    }, "A"_a);
+
+    // -- inv (matrix inverse) ---------------------------------------------
+    m.def("inv", [](const MV& A_mv) {
+        if (A_mv.mat.num_cols() != A_mv.mat.num_rows())
+            throw std::invalid_argument("inv: A must be square");
+        Mat A = copy_to_dense(A_mv);
+        auto Ainv = mtl::inv(A);
+        return MV(std::move(Ainv));
+    }, "A"_a, "Compute matrix inverse via LU factorization");
+
+    m.def("inv",
+          [](nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu> A_np) {
+        if (A_np.shape(0) != A_np.shape(1))
+            throw std::invalid_argument("inv: A must be square");
+        Mat A = copy_ndarray_to_dense<T>(A_np);
+        auto Ainv = mtl::inv(A);
+        return MV(std::move(Ainv));
+    }, "A"_a);
+
+    // -- LU factorization object ------------------------------------------
+    using LUF = LUFactor<T>;
+    std::string lu_name = std::string("LUFactor_") + type_suffix<T>();
+    nb::class_<LUF>(m, lu_name.c_str())
+        .def("solve", [](const LUF& self, const VV& b_vv) {
+            if (b_vv.vec.size() != self.n)
+                throw std::invalid_argument("LU.solve: dimension mismatch");
+            Vec b(self.n);
+            for (std::size_t i = 0; i < self.n; ++i) b[i] = b_vv.vec[i];
+            Vec x(self.n);
+            mtl::lu_solve(self.LU, self.pivot, x, b);
+            return VV(std::move(x));
+        }, "b"_a, "Solve LUx = b for the previously factored A")
+        .def("solve",
+             [](const LUF& self,
+                nb::ndarray<T, nb::ndim<1>, nb::c_contig, nb::device::cpu> b_np) {
+            if (b_np.shape(0) != self.n)
+                throw std::invalid_argument("LU.solve: dimension mismatch");
+            Vec b(self.n);
+            for (std::size_t i = 0; i < self.n; ++i) b[i] = b_np.data()[i];
+            Vec x(self.n);
+            mtl::lu_solve(self.LU, self.pivot, x, b);
+            return VV(std::move(x));
+        }, "b"_a)
+        .def_prop_ro("n", [](const LUF& self) { return self.n; })
+        .def("__repr__", [](const LUF& self) {
+            return std::string("mtl5.LUFactor_") + type_suffix<T>() +
+                   "(n=" + std::to_string(self.n) + ")";
+        });
+
+    m.def("lu", [](const MV& A_mv) {
+        if (A_mv.mat.num_cols() != A_mv.mat.num_rows())
+            throw std::invalid_argument("lu: A must be square");
+        return LUF(A_mv.mat);
+    }, "A"_a, "Return LU factorization of A");
+
+    m.def("lu",
+          [](nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu> A_np) {
+        if (A_np.shape(0) != A_np.shape(1))
+            throw std::invalid_argument("lu: A must be square");
+        Mat A = copy_ndarray_to_dense<T>(A_np);
+        return LUF(A);
+    }, "A"_a);
+
+    // -- Cholesky factorization object ------------------------------------
+    using CF = CholeskyFactor<T>;
+    std::string ch_name = std::string("CholeskyFactor_") + type_suffix<T>();
+    nb::class_<CF>(m, ch_name.c_str())
+        .def("solve", [](const CF& self, const VV& b_vv) {
+            if (b_vv.vec.size() != self.n)
+                throw std::invalid_argument("cholesky.solve: dimension mismatch");
+            Vec b(self.n);
+            for (std::size_t i = 0; i < self.n; ++i) b[i] = b_vv.vec[i];
+            Vec x(self.n);
+            mtl::cholesky_solve(self.L, x, b);
+            return VV(std::move(x));
+        }, "b"_a, "Solve A·x = b using the Cholesky factor")
+        .def("solve",
+             [](const CF& self,
+                nb::ndarray<T, nb::ndim<1>, nb::c_contig, nb::device::cpu> b_np) {
+            if (b_np.shape(0) != self.n)
+                throw std::invalid_argument("cholesky.solve: dimension mismatch");
+            Vec b(self.n);
+            for (std::size_t i = 0; i < self.n; ++i) b[i] = b_np.data()[i];
+            Vec x(self.n);
+            mtl::cholesky_solve(self.L, x, b);
+            return VV(std::move(x));
+        }, "b"_a)
+        .def_prop_ro("n", [](const CF& self) { return self.n; })
+        .def("__repr__", [](const CF& self) {
+            return std::string("mtl5.CholeskyFactor_") + type_suffix<T>() +
+                   "(n=" + std::to_string(self.n) + ")";
+        });
+
+    m.def("cholesky", [](const MV& A_mv) {
+        if (A_mv.mat.num_cols() != A_mv.mat.num_rows())
+            throw std::invalid_argument("cholesky: A must be square");
+        return CF(A_mv.mat);
+    }, "A"_a, "Return Cholesky factorization of an SPD matrix A");
+
+    m.def("cholesky",
+          [](nb::ndarray<T, nb::ndim<2>, nb::c_contig, nb::device::cpu> A_np) {
+        if (A_np.shape(0) != A_np.shape(1))
+            throw std::invalid_argument("cholesky: A must be square");
+        Mat A = copy_ndarray_to_dense<T>(A_np);
+        return CF(A);
+    }, "A"_a);
+}
+
+// ===========================================================================
 // Registration for Universal types (fp8, fp16, posit, etc.)
 // These always copy (no NumPy dtype), but get device stubs
 // ===========================================================================
@@ -557,6 +871,7 @@ template <typename T>
 void register_native_with_solve(nb::module_& m) {
     register_native<T>(m);
     register_native_solve<T>(m);
+    register_native_dense_ops<T>(m);
 }
 
 template <typename T>
@@ -578,11 +893,46 @@ NB_MODULE(_core, m) {
 
     m.attr("__version__") = "0.1.0";
 
-    // ----- Device management -------------------------------------------------
+    // ----- Device & backend management ---------------------------------------
     m.def("devices", []() {
         return std::vector<std::string>{"cpu"};
-        // Future: enumerate KPU devices, BLAS backends
+        // Future: enumerate KPU devices
     }, "List available execution devices");
+
+    m.def("backends", []() {
+        // Reports the dispatch hierarchy from highest to lowest preference.
+        // KPU is the principal target; CPU reference is the portable fallback.
+        std::vector<std::string> b;
+#ifdef MTL5_HAS_KPU
+        b.push_back("kpu");
+#endif
+#ifdef MTL5_HAS_BLAS
+        b.push_back("blas");
+#endif
+        b.push_back("reference");
+        return b;
+    }, "List available compute backends in dispatch order (KPU > BLAS > reference)");
+
+    m.def("get_backend", []() {
+#ifdef MTL5_HAS_KPU
+        return std::string("kpu");
+#elif defined(MTL5_HAS_BLAS)
+        return std::string("blas");
+#else
+        return std::string("reference");
+#endif
+    }, "Return the currently active compute backend");
+
+    m.def("set_backend", [](const std::string& name) {
+        // Stub: backend selection is currently compile-time only
+        if (name != "cpu" && name != "reference" && name != "blas" && name != "kpu")
+            throw std::runtime_error("Unknown backend: '" + name +
+                                     "'. Valid: cpu, reference, blas, kpu");
+        if (name == "kpu")
+            throw std::runtime_error("KPU backend not yet available. "
+                                     "Hardware support is in development.");
+        // No-op for cpu/reference/blas — selected at compile time
+    }, "name"_a, "Set the active compute backend (currently compile-time only)");
 
     // ----- Native C++ types (zero-copy via nb::ndarray) ----------------------
     register_native_with_solve<float>(m);     // f32

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,0 +1,213 @@
+"""Tests for dense linear algebra operations: matmul, transpose, det, inv, lu, cholesky."""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import mtl5
+
+
+class TestMatmul:
+    def test_matmul_views(self, rng):
+        A_np = rng.standard_normal((5, 4))
+        B_np = rng.standard_normal((4, 6))
+        A = mtl5.matrix(A_np)
+        B = mtl5.matrix(B_np)
+        C = mtl5.matmul(A, B)
+        npt.assert_allclose(C.to_numpy(), A_np @ B_np, rtol=1e-12)
+
+    def test_matmul_ndarray(self, rng):
+        A = rng.standard_normal((5, 4))
+        B = rng.standard_normal((4, 6))
+        C = mtl5.matmul(A, B)
+        npt.assert_allclose(C.to_numpy(), A @ B, rtol=1e-12)
+
+    def test_matmul_operator(self, rng):
+        A_np = rng.standard_normal((4, 4))
+        B_np = rng.standard_normal((4, 4))
+        A = mtl5.matrix(A_np)
+        B = mtl5.matrix(B_np)
+        C = A @ B
+        npt.assert_allclose(C.to_numpy(), A_np @ B_np, rtol=1e-12)
+
+    def test_matmul_dimension_mismatch(self):
+        A = np.ones((3, 4))
+        B = np.ones((5, 6))
+        with pytest.raises(ValueError):
+            mtl5.matmul(A, B)
+
+
+class TestMatvec:
+    def test_matvec(self, rng):
+        A_np = rng.standard_normal((5, 4))
+        x_np = rng.standard_normal(4)
+        A = mtl5.matrix(A_np)
+        x = mtl5.vector(x_np)
+        y = mtl5.matvec(A, x)
+        npt.assert_allclose(y.to_numpy(), A_np @ x_np, rtol=1e-12)
+
+    def test_matrix_at_vector_operator(self, rng):
+        A_np = rng.standard_normal((5, 4))
+        x_np = rng.standard_normal(4)
+        A = mtl5.matrix(A_np)
+        x = mtl5.vector(x_np)
+        y = A @ x
+        npt.assert_allclose(y.to_numpy(), A_np @ x_np, rtol=1e-12)
+
+
+class TestTranspose:
+    def test_transpose_function(self, rng):
+        A_np = rng.standard_normal((3, 5))
+        A = mtl5.matrix(A_np)
+        AT = mtl5.transpose(A)
+        assert AT.shape == (5, 3)
+        npt.assert_allclose(AT.to_numpy(), A_np.T, rtol=1e-14)
+
+    def test_T_property(self, rng):
+        A_np = rng.standard_normal((4, 6))
+        A = mtl5.matrix(A_np)
+        AT = A.T
+        assert AT.shape == (6, 4)
+        npt.assert_allclose(AT.to_numpy(), A_np.T, rtol=1e-14)
+
+
+class TestDet:
+    def test_det_identity(self):
+        A = np.eye(5)
+        assert mtl5.det(A) == pytest.approx(1.0)
+
+    def test_det_2x2(self):
+        A = np.array([[1.0, 2.0], [3.0, 4.0]])
+        # det = 1*4 - 2*3 = -2
+        assert mtl5.det(A) == pytest.approx(-2.0, rel=1e-12)
+
+    def test_det_matches_numpy(self, rng):
+        for n in [3, 5, 10]:
+            A = rng.standard_normal((n, n)) + n * np.eye(n)
+            d_mtl5 = mtl5.det(A)
+            d_numpy = np.linalg.det(A)
+            npt.assert_allclose(d_mtl5, d_numpy, rtol=1e-10)
+
+    def test_det_singular(self):
+        A = np.array([[1.0, 2.0], [2.0, 4.0]])  # rank 1
+        assert mtl5.det(A) == pytest.approx(0.0, abs=1e-12)
+
+    def test_det_non_square_raises(self):
+        with pytest.raises(ValueError):
+            mtl5.det(mtl5.matrix(np.ones((3, 4))))
+
+
+class TestInv:
+    def test_inv_identity(self):
+        A = np.eye(4)
+        Ainv = mtl5.inv(A)
+        npt.assert_allclose(Ainv.to_numpy(), np.eye(4), atol=1e-14)
+
+    def test_inv_round_trip(self, rng):
+        n = 6
+        A = rng.standard_normal((n, n)) + n * np.eye(n)
+        Ainv = mtl5.inv(A).to_numpy()
+        npt.assert_allclose(A @ Ainv, np.eye(n), atol=1e-10)
+        npt.assert_allclose(Ainv @ A, np.eye(n), atol=1e-10)
+
+    def test_inv_matches_numpy(self, rng):
+        n = 8
+        A = rng.standard_normal((n, n)) + n * np.eye(n)
+        Ainv_mtl5 = mtl5.inv(A).to_numpy()
+        Ainv_numpy = np.linalg.inv(A)
+        npt.assert_allclose(Ainv_mtl5, Ainv_numpy, rtol=1e-10)
+
+
+class TestLUFactor:
+    def test_lu_object(self, rng):
+        n = 6
+        A = rng.standard_normal((n, n)) + n * np.eye(n)
+        b = rng.standard_normal(n)
+
+        lu_factor = mtl5.lu(A)
+        assert lu_factor.n == n
+
+        x = lu_factor.solve(b)
+        npt.assert_allclose(A @ x.to_numpy(), b, atol=1e-10)
+
+    def test_lu_repeated_solve(self, rng):
+        """Verify factorization can be reused for multiple RHS."""
+        n = 5
+        A = rng.standard_normal((n, n)) + n * np.eye(n)
+        lu_factor = mtl5.lu(A)
+
+        for _ in range(3):
+            b = rng.standard_normal(n)
+            x = lu_factor.solve(b)
+            npt.assert_allclose(A @ x.to_numpy(), b, atol=1e-10)
+
+    def test_lu_singular_raises(self):
+        A = np.array([[1.0, 2.0], [2.0, 4.0]])
+        with pytest.raises(RuntimeError, match="singular"):
+            mtl5.lu(A)
+
+
+class TestCholeskyFactor:
+    @staticmethod
+    def make_spd(n: int, rng: np.random.Generator) -> np.ndarray:
+        """Construct a symmetric positive-definite matrix."""
+        L = np.tril(rng.standard_normal((n, n)))
+        # Ensure positive diagonal
+        np.fill_diagonal(L, np.abs(np.diag(L)) + n)
+        return L @ L.T
+
+    def test_cholesky_spd(self, rng):
+        n = 6
+        A = self.make_spd(n, rng)
+        b = rng.standard_normal(n)
+
+        chol = mtl5.cholesky(A)
+        assert chol.n == n
+
+        x = chol.solve(b)
+        npt.assert_allclose(A @ x.to_numpy(), b, atol=1e-10)
+
+    def test_cholesky_repeated_solve(self, rng):
+        n = 5
+        A = self.make_spd(n, rng)
+        chol = mtl5.cholesky(A)
+
+        for _ in range(3):
+            b = rng.standard_normal(n)
+            x = chol.solve(b)
+            npt.assert_allclose(A @ x.to_numpy(), b, atol=1e-10)
+
+    def test_cholesky_non_spd_raises(self):
+        A = np.array([[1.0, 2.0], [2.0, 1.0]])  # not SPD (negative eigenvalue)
+        with pytest.raises(RuntimeError, match="positive definite"):
+            mtl5.cholesky(A)
+
+    def test_cholesky_matches_numpy(self, rng):
+        n = 10
+        A = self.make_spd(n, rng)
+        b = rng.standard_normal(n)
+        chol = mtl5.cholesky(A)
+        x_mtl5 = chol.solve(b).to_numpy()
+        x_numpy = np.linalg.solve(A, b)
+        npt.assert_allclose(x_mtl5, x_numpy, rtol=1e-10)
+
+
+class TestBackendAPI:
+    def test_backends(self):
+        bs = mtl5.backends()
+        assert "reference" in bs
+
+    def test_get_backend(self):
+        backend = mtl5.get_backend()
+        assert isinstance(backend, str)
+
+    def test_set_backend_valid(self):
+        mtl5.set_backend("cpu")  # no-op, just shouldn't raise
+
+    def test_set_backend_unknown(self):
+        with pytest.raises(RuntimeError, match="Unknown backend"):
+            mtl5.set_backend("nonexistent")
+
+    def test_set_backend_kpu_not_available(self):
+        with pytest.raises(RuntimeError, match="not yet available"):
+            mtl5.set_backend("kpu")


### PR DESCRIPTION
## Summary
- Adds dense linear algebra operations to complete the dense linalg binding scope
- New operations: matmul/matvec, transpose, det, inv, LUFactor, CholeskyFactor
- Adds @ matmul operator and .T property on MatrixView
- Backend management API: backends(), get_backend(), set_backend()
- Fixes a use-after-free bug in to_numpy() chained calls

## Changes
- python/src/mtl5_module.cpp — register_native_dense_ops template; LUFactor/CholeskyFactor classes; backend API stubs; nb::handle fix for to_numpy
- mtl5/__init__.py — export new symbols
- tests/test_linalg.py — 28 new tests covering matmul, transpose, det, inv, LU/Cholesky factorization, backend API

## Use-After-Free Fix
Chained calls like \`solve(b).to_numpy()\` returned uninitialized memory because \`nb::cast(vv)\` on a C++ reference creates a separate Python wrapper whose internal copy has different storage from the source. The NumPy array pointed to the temporary's data while the keep-alive held a different copy. Fixed by using \`nb::handle self\` parameter to access the actual Python wrapper.

## Test Results
| Suite | Count | Status |
|-------|-------|--------|
| test_import | 8 | PASS |
| test_vector | 26 | PASS |
| test_matrix | 16 | PASS |
| test_universal | 25 | PASS |
| test_linalg (new) | 28 | PASS |
| ... others | 6 | PASS |
| **Total** | **109** | **ALL PASS** |

## Test plan
- [x] CI passes on Linux/macOS/Windows
- [x] Promote to ready when satisfied: \`gh pr ready\`

Resolves #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)