### PR TITLE
feat(build): automate SEMVER with python-semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: semantic-release version --no-push --no-vcs-release --skip-build || true
+        run: semantic-release version --no-push --no-vcs-release --skip-build
 
       - name: Check if version was bumped
         id: check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+# Triggered on push to main after CI passes.
+# python-semantic-release analyzes conventional commits since the last tag,
+# determines if a version bump is needed, updates pyproject.toml, creates
+# a git tag, and publishes a GitHub Release.
+#
+# Versioning policy:
+#   - mtl5-python follows MTL5's major.minor version (currently 5.2.x)
+#   - semantic-release only manages the PATCH component
+#   - feat: and fix: commits both trigger a patch bump
+#   - Major/minor bumps are manual to align with MTL5 upstream releases
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write  # push tags and create releases
+  id-token: write  # trusted publishing (future PyPI)
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Only run if CI passed (release depends on the CI workflow)
+    concurrency:
+      group: release
+      cancel-in-progress: false
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # full history needed for commit analysis
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install python-semantic-release
+        run: pip install python-semantic-release
+
+      - name: Run semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semantic-release version --no-push --no-vcs-release --skip-build || true
+
+      - name: Check if version was bumped
+        id: check
+        run: |
+          if git diff --name-only | grep -q pyproject.toml; then
+            echo "bumped=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "bumped=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit, tag, and push
+        if: steps.check.outputs.bumped == 'true'
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore(release): v${VERSION}"
+          git tag "v${VERSION}"
+          git push origin main --tags
+
+      - name: Create GitHub Release
+        if: steps.check.outputs.bumped == 'true'
+        run: |
+          VERSION=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --generate-notes \
+            --latest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/designs/multi-precision-type-dispatch.md
+++ b/docs/designs/multi-precision-type-dispatch.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Implemented (v0.1.0) for IEEE types. Universal number types pending custom dtype registration (#5).
+Implemented for IEEE types. Universal number types added as named factories (issue #5 Phase 1).
 
 ## Need
 

--- a/docs/designs/multi-precision-type-dispatch.md
+++ b/docs/designs/multi-precision-type-dispatch.md
@@ -2,7 +2,9 @@
 
 ## Status
 
-Implemented for IEEE types. Universal number types added as named factories (issue #5 Phase 1).
+**IEEE types** (f32, f64, i32, i64): fully implemented with automatic dtype dispatch via `nb::ndarray` — `mtl5.vector(np_array)` selects the right type based on the input dtype.
+
+**Universal types** (posit8/16/32/64, fixpnt8/16, lns16/32, fp8, fp16): available via named factory functions (`mtl5.vector_posit16(np_array)`, `mtl5.matrix_fp8(np_array)`, etc.). Automatic `vector()` dtype dispatch for Universal types requires custom NumPy dtype registration (issue #14, Phase 2).
 
 ## Need
 

--- a/mtl5/__init__.py
+++ b/mtl5/__init__.py
@@ -1,10 +1,19 @@
 """MTL5 Python bindings — NumPy/SciPy/JAX/PyTorch interop with hardware accelerator dispatch."""
 
+from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
 
 # Single source of truth: pyproject.toml → installed package metadata.
 # The C++ module also reads this at build time via CMake.
-__version__ = _pkg_version("mtl5")
+# Falls back to the C++ extension's version when running from a source tree
+# without installed metadata (e.g. an in-place build without pip install).
+try:
+    __version__ = _pkg_version("mtl5")
+except PackageNotFoundError:
+    try:
+        from mtl5._core import __version__  # noqa: F811
+    except ImportError:
+        __version__ = "0.0.0-dev"
 
 from mtl5._core import (
     # Cholesky factorization objects

--- a/mtl5/__init__.py
+++ b/mtl5/__init__.py
@@ -1,5 +1,11 @@
 """MTL5 Python bindings — NumPy/SciPy/JAX/PyTorch interop with hardware accelerator dispatch."""
 
+from importlib.metadata import version as _pkg_version
+
+# Single source of truth: pyproject.toml → installed package metadata.
+# The C++ module also reads this at build time via CMake.
+__version__ = _pkg_version("mtl5")
+
 from mtl5._core import (
     # Cholesky factorization objects
     CholeskyFactor_f32,
@@ -40,7 +46,6 @@ from mtl5._core import (
     # LU factorization objects
     LUFactor_f32,
     LUFactor_f64,
-    __version__,
     # Backend management
     backends,
     cholesky,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "mtl5"
-version = "0.1.0"
+version = "5.2.0"
 description = "Python bindings for MTL5 — NumPy/SciPy/JAX/PyTorch interop with hardware accelerator dispatch"
 readme = "README.md"
 license = {text = "MIT"}
@@ -36,3 +36,36 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
+
+# ---------------------------------------------------------------------------
+# python-semantic-release configuration
+#
+# mtl5-python follows MTL5's major.minor version. Semantic-release manages
+# only the PATCH component based on conventional commit messages:
+#   feat: → patch bump (NOT minor — minor tracks MTL5 upstream)
+#   fix:  → patch bump
+#   breaking change → manual intervention (must align with MTL5 major bump)
+#
+# When MTL5 upstream releases a new major.minor (e.g. 5.3.0), manually set
+# the version in pyproject.toml to match, then let semantic-release resume
+# patch management from there.
+# ---------------------------------------------------------------------------
+[tool.semantic_release]
+version_toml = ["pyproject.toml:project.version"]
+tag_format = "v{version}"
+commit_message = "chore(release): v{version}"
+major_on_zero = false
+branch = "main"
+
+[tool.semantic_release.commit_parser_options]
+# Override: treat feat as patch (not minor) since minor tracks MTL5 upstream.
+# Only an explicit "BREAKING CHANGE" footer triggers a minor bump here — but
+# in practice, minor/major bumps are manual to align with MTL5.
+minor_types = []
+patch_types = ["feat", "fix", "perf", "refactor"]
+
+[tool.semantic_release.changelog]
+changelog_file = "CHANGELOG.md"
+
+[tool.semantic_release.publish]
+upload_to_pypi = false

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -16,6 +16,16 @@ endif()
 
 nanobind_add_module(_core src/mtl5_module.cpp)
 
+# Inject the package version from pyproject.toml into the C++ module via a
+# compile definition. scikit-build-core sets SKBUILD_PROJECT_VERSION; fall back
+# to the CMake project version if building outside of pip.
+if(DEFINED SKBUILD_PROJECT_VERSION)
+    set(_MTL5PY_VERSION "${SKBUILD_PROJECT_VERSION}")
+else()
+    set(_MTL5PY_VERSION "${CMAKE_PROJECT_VERSION}")
+endif()
+target_compile_definitions(_core PRIVATE MTL5PY_VERSION="${_MTL5PY_VERSION}")
+
 # Use namespaced target — works for both find_package and FetchContent
 # (FetchContent creates both 'mtl5' and 'MTL5::mtl5' alias)
 target_link_libraries(_core PRIVATE MTL5::mtl5 universal)

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -18,11 +18,14 @@ nanobind_add_module(_core src/mtl5_module.cpp)
 
 # Inject the package version from pyproject.toml into the C++ module via a
 # compile definition. scikit-build-core sets SKBUILD_PROJECT_VERSION; fall back
-# to the CMake project version if building outside of pip.
-if(DEFINED SKBUILD_PROJECT_VERSION)
+# to the CMake project version, then to "0.0.0-dev" if neither is available
+# (e.g. standalone cmake invocation without scikit-build or project VERSION).
+if(DEFINED SKBUILD_PROJECT_VERSION AND NOT "${SKBUILD_PROJECT_VERSION}" STREQUAL "")
     set(_MTL5PY_VERSION "${SKBUILD_PROJECT_VERSION}")
-else()
+elseif(DEFINED CMAKE_PROJECT_VERSION AND NOT "${CMAKE_PROJECT_VERSION}" STREQUAL "")
     set(_MTL5PY_VERSION "${CMAKE_PROJECT_VERSION}")
+else()
+    set(_MTL5PY_VERSION "0.0.0-dev")
 endif()
 target_compile_definitions(_core PRIVATE MTL5PY_VERSION="${_MTL5PY_VERSION}")
 

--- a/python/src/mtl5_module.cpp
+++ b/python/src/mtl5_module.cpp
@@ -1251,7 +1251,12 @@ void register_preconditioners(nb::module_& m) {
 NB_MODULE(_core, m) {
     m.doc() = "MTL5 Python bindings — nanobind core module";
 
-    m.attr("__version__") = "0.1.0";
+    // Version injected from pyproject.toml via CMake compile definition
+#ifdef MTL5PY_VERSION
+    m.attr("__version__") = MTL5PY_VERSION;
+#else
+    m.attr("__version__") = "0.0.0-dev";
+#endif
 
     // ----- Device & backend management ---------------------------------------
     m.def("devices", []() {

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -15,6 +15,16 @@ def test_version_string():
     assert all(p.isdigit() for p in parts[:3])
 
 
+def test_version_sync():
+    """Python package version must match the C++ extension module version."""
+    import mtl5._core as _core
+
+    assert mtl5.__version__ == _core.__version__, (
+        f"Version mismatch: mtl5.__version__={mtl5.__version__!r} "
+        f"vs _core.__version__={_core.__version__!r}"
+    )
+
+
 def test_public_api():
     for name in ["vector", "vector_copy", "matrix", "matrix_copy", "norm", "dot", "solve"]:
         assert hasattr(mtl5, name), f"mtl5.{name} not found"

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -9,7 +9,10 @@ def test_import():
 
 def test_version_string():
     assert isinstance(mtl5.__version__, str)
-    assert mtl5.__version__ == "0.1.0"
+    # Version must be a valid semver (major.minor.patch)
+    parts = mtl5.__version__.split(".")
+    assert len(parts) >= 3, f"Expected semver, got '{mtl5.__version__}'"
+    assert all(p.isdigit() for p in parts[:3])
 
 
 def test_public_api():


### PR DESCRIPTION
## Summary
Eliminates 4 hardcoded version strings by making `pyproject.toml` the single source of truth. Adds automated patch versioning via `python-semantic-release` on merge to main.

## Version strategy
- **mtl5-python tracks MTL5's major.minor** — currently `5.2.x` (matching MTL5 v5.2.0)
- `python-semantic-release` manages only PATCH: `feat:` and `fix:` commits both trigger a patch bump
- Major/minor bumps are manual — done when MTL5 upstream releases a new major.minor
- `BREAKING CHANGE` footer is reserved for manual intervention

## How the version flows

```
pyproject.toml (5.2.0)
  ├─→ pip install → importlib.metadata.version("mtl5") → mtl5.__version__
  └─→ scikit-build-core → SKBUILD_PROJECT_VERSION → CMake → MTL5PY_VERSION define → mtl5._core.__version__
```

## Changes
- `pyproject.toml` — version `0.1.0` → `5.2.0`, semantic_release config
- `mtl5/__init__.py` — `__version__` from `importlib.metadata` instead of C++ import
- `python/CMakeLists.txt` — inject `SKBUILD_PROJECT_VERSION` as `MTL5PY_VERSION` compile def
- `python/src/mtl5_module.cpp` — read `MTL5PY_VERSION` macro instead of hardcoded string
- `tests/test_import.py` — validate semver format, not hardcoded value
- `.github/workflows/release.yml` — semantic-release on push to main

## Test plan
- [x] CI passes (201 tests)
- [x] `mtl5.__version__` and `mtl5._core.__version__` both report `5.2.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project version to 5.2.0.
  * Implemented automated release workflow for streamlined version management and release creation.

* **Documentation**
  * Updated design documentation to reflect the current implementation status of type dispatch features.

* **Tests**
  * Enhanced version validation to support flexible semantic versioning formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->